### PR TITLE
Add compressed image support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ ROS2 Bag Exporter is a versatile ROS 2 (Humble Hawksbill) c++ package designed t
 #### Support for Multiple Message Types:
 - **PointCloud2**: Export point cloud data to PCD files.
 - **Image**: Convert image messages to PNG format.
+- **CompressedImage**: Convert image messages to JPG or PNG format.
 - **IR Image**: Convert IR image messages to PNG format.
 - **DepthImage**: Export depth images with appropriate encoding.
 - **LaserScan**: Export laser scan data.
@@ -89,6 +90,9 @@ topics:
   - name: "/camera/color/image_raw"
     type: "Image"
     encoding: "rgb8"
+    sample_interval: 5   # Write one sample every 5 messages
+  - name: "/camera/color/image_raw/compressed"
+    type: "CompressedImage"
     sample_interval: 5   # Write one sample every 5 messages
   - name: "/imu_topic"
     type: "IMU"

--- a/include/rosbag2_exporter/bag_exporter.hpp
+++ b/include/rosbag2_exporter/bag_exporter.hpp
@@ -9,6 +9,7 @@
 #include "rosbag2_exporter/handlers/base_handler.hpp"
 #include "rosbag2_exporter/handlers/pointcloud_handler.hpp"
 #include "rosbag2_exporter/handlers/image_handler.hpp"
+#include "rosbag2_exporter/handlers/compressed_image_handler.hpp"
 #include "rosbag2_exporter/handlers/depth_image_handler.hpp"
 #include "rosbag2_exporter/handlers/ir_image_handler.hpp"
 #include "rosbag2_exporter/handlers/laser_scan_handler.hpp"
@@ -38,6 +39,7 @@ enum class MessageType
   PointCloud2,
   LaserScan,
   Image,
+  CompressedImage,
   DepthImage,
   IRImage,
   IMU,

--- a/include/rosbag2_exporter/handlers/compressed_image_handler.hpp
+++ b/include/rosbag2_exporter/handlers/compressed_image_handler.hpp
@@ -1,0 +1,101 @@
+/*
+ * This file is based on the original work by:
+ * 
+ * Original Author: Abdalrahman M. Amer, www.linkedin.com/in/abdalrahman-m-amer
+ * Original Date: 13.10.2024
+ * 
+ * Adapted and Modified By: Hector Cruz, hcruzgo@ed.ac.uk
+ * Adaptation Date: 24.01.2025
+ * 
+ * Description of Adaptations:
+ * - Used as a template to support CompressedImages handling
+ */
+
+#ifndef ROSBAG2_EXPORTER__HANDLERS__COMPRESSED_IMAGE_HANDLER_HPP_
+#define ROSBAG2_EXPORTER__HANDLERS__COMPRESSED_IMAGE_HANDLER_HPP_
+
+#include "rosbag2_exporter/handlers/base_handler.hpp"
+#include <sensor_msgs/msg/compressed_image.hpp>
+#include <iomanip>
+#include <sstream>
+#include <filesystem>
+
+namespace rosbag2_exporter
+{
+
+class CompressedImageHandler : public BaseHandler
+{
+public:
+
+  CompressedImageHandler(const std::string & output_dir,
+               const std::string & encoding,
+               rclcpp::Logger logger)
+  : BaseHandler(logger), output_dir_(output_dir)
+  {}
+
+  // Handle compressed image messages
+  void process_message(const rclcpp::SerializedMessage & serialized_msg,
+                                  const std::string & topic,
+                                  size_t index) override
+  {
+    // Deserialize the incoming compressed image message
+    sensor_msgs::msg::CompressedImage compressed_img;
+    rclcpp::Serialization<sensor_msgs::msg::CompressedImage> serializer;
+    serializer.deserialize_message(&serialized_msg, &compressed_img);
+
+    // Determine file extension based on the compressed image format
+    std::string extension;
+    if (compressed_img.format.find("jpeg") != std::string::npos || compressed_img.format.find("jpg") != std::string::npos) {
+      extension = ".jpg";
+    } else if (compressed_img.format.find("png") != std::string::npos) {
+      extension = ".png";
+    } else {
+      RCLCPP_WARN(logger_, "Unknown compressed image format: %s. Defaulting to '.jpg'", compressed_img.format.c_str());
+      extension = ".jpg";  // Default to JPEG if unknown
+    }
+
+    // Create a timestamped filename and save compressed image directly
+    std::stringstream ss_timestamp;
+    ss_timestamp << compressed_img.header.stamp.sec << "-"
+                 << std::setw(9) << std::setfill('0') << compressed_img.header.stamp.nanosec;
+    std::string timestamp = ss_timestamp.str();
+
+    std::string sanitized_topic = topic;
+    // RCLCPP_WARN(logger_, "Topic-> %s", sanitized_topic.c_str());
+    if (!sanitized_topic.empty() && sanitized_topic[0] == '/') {
+      sanitized_topic = sanitized_topic.substr(1);
+    }
+
+    // Create the full file path
+    std::string filepath = output_dir_ + "/" + sanitized_topic + "/" + timestamp + extension;
+
+    // Ensure the directory exists, create if necessary
+    std::filesystem::path dir_path = output_dir_ + "/" + sanitized_topic;
+    if (!std::filesystem::exists(dir_path)) {
+      RCLCPP_INFO(logger_, "Creating directory: %s", dir_path.c_str());
+      std::filesystem::create_directories(dir_path);
+    }
+
+    // Save the compressed image data directly to file
+    std::ofstream outfile(filepath, std::ios::binary);
+    if (!outfile.is_open()) {
+      RCLCPP_ERROR(logger_, "Failed to open file to write compressed image: %s", filepath.c_str());
+      return;
+    }
+    outfile.write(reinterpret_cast<const char*>(compressed_img.data.data()), compressed_img.data.size());
+    outfile.close();
+
+    RCLCPP_INFO(logger_, "Successfully wrote compressed image to %s", filepath.c_str());
+  }
+
+
+private:
+  std::string output_dir_;
+  // Defined to comply with class parent but not needed
+  std::string encoding_; 
+
+};
+
+}  // namespace rosbag2_exporter
+
+#endif  // ROSBAG2_EXPORTER__HANDLERS__COMPRESSED_IMAGE_HANDLER_HPP_

--- a/include/rosbag2_exporter/handlers/compressed_image_handler.hpp
+++ b/include/rosbag2_exporter/handlers/compressed_image_handler.hpp
@@ -61,7 +61,6 @@ public:
     std::string timestamp = ss_timestamp.str();
 
     std::string sanitized_topic = topic;
-    // RCLCPP_WARN(logger_, "Topic-> %s", sanitized_topic.c_str());
     if (!sanitized_topic.empty() && sanitized_topic[0] == '/') {
       sanitized_topic = sanitized_topic.substr(1);
     }

--- a/include/rosbag2_exporter/handlers/image_handler.hpp
+++ b/include/rosbag2_exporter/handlers/image_handler.hpp
@@ -1,6 +1,14 @@
 /*
- * Author: Abdalrahman M. Amer, www.linkedin.com/in/abdalrahman-m-amer
- * Date: 13.10.2024
+ * This file is based on the original work by:
+ * 
+ * Original Author: Abdalrahman M. Amer, www.linkedin.com/in/abdalrahman-m-amer
+ * Original Date: 13.10.2024
+ * 
+ * Modified By: Hector Cruz, hcruzgo@ed.ac.uk
+ * Modification Date: 27.01.2025
+ * 
+ * Changes:
+ * - Remove unused process_compressed_message member function
  */
 
 #ifndef ROSBAG2_EXPORTER__HANDLERS__IMAGE_HANDLER_HPP_
@@ -79,60 +87,6 @@ public:
 
       // Save the image to file
       save_image(cv_ptr->image, topic, img.header.stamp);
-  }
-
-  // Handle compressed image messages
-  void process_compressed_message(const rclcpp::SerializedMessage & serialized_msg,
-                                  const std::string & topic,
-                                  size_t index)
-  {
-    // Deserialize the incoming compressed image message
-    sensor_msgs::msg::CompressedImage compressed_img;
-    rclcpp::Serialization<sensor_msgs::msg::CompressedImage> serializer;
-    serializer.deserialize_message(&serialized_msg, &compressed_img);
-
-    // Determine file extension based on the compressed image format
-    std::string extension;
-    if (compressed_img.format.find("jpeg") != std::string::npos || compressed_img.format.find("jpg") != std::string::npos) {
-      extension = ".jpg";
-    } else if (compressed_img.format.find("png") != std::string::npos) {
-      extension = ".png";
-    } else {
-      RCLCPP_WARN(logger_, "Unknown compressed image format: %s. Defaulting to '.jpg'", compressed_img.format.c_str());
-      extension = ".jpg";  // Default to JPEG if unknown
-    }
-
-    // Create a timestamped filename and save compressed image directly
-    std::stringstream ss_timestamp;
-    ss_timestamp << compressed_img.header.stamp.sec << "-"
-                 << std::setw(9) << std::setfill('0') << compressed_img.header.stamp.nanosec;
-    std::string timestamp = ss_timestamp.str();
-
-    std::string sanitized_topic = topic;
-    if (!sanitized_topic.empty() && sanitized_topic[0] == '/') {
-      sanitized_topic = sanitized_topic.substr(1);
-    }
-
-    // Create the full file path
-    std::string filepath = output_dir_ + "/" + sanitized_topic + "/" + timestamp + extension;
-
-    // Ensure the directory exists, create if necessary
-    std::filesystem::path dir_path = output_dir_ + "/" + sanitized_topic;
-    if (!std::filesystem::exists(dir_path)) {
-      RCLCPP_INFO(logger_, "Creating directory: %s", dir_path.c_str());
-      std::filesystem::create_directories(dir_path);
-    }
-
-    // Save the compressed image data directly to file
-    std::ofstream outfile(filepath, std::ios::binary);
-    if (!outfile.is_open()) {
-      RCLCPP_ERROR(logger_, "Failed to open file to write compressed image: %s", filepath.c_str());
-      return;
-    }
-    outfile.write(reinterpret_cast<const char*>(compressed_img.data.data()), compressed_img.data.size());
-    outfile.close();
-
-    RCLCPP_INFO(logger_, "Successfully wrote compressed image to %s", filepath.c_str());
   }
 
 private:


### PR DESCRIPTION
- Add `compressed_image_handler.hpp` to define CompressedImage support
- Add `CompressedImage` as `MessageType`
- Fix `config_file` param to accept absolute paths instead
- Remove `process_compressed_message` unused function