### PR TITLE
Fix path dir generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,16 +87,16 @@ topics:
     type: "DepthImage"
     encoding: "16UC1"
     sample_interval: 10  # Write one sample every 10 messages
-    topic_dir: "depth_raw"  # Output data in <output_dir>/depth_raw
+    topic_dir: "depth_raw"  # Output data in <output_dir>/<bag_name>/depth_raw
   - name: "/camera/color/image_raw"
     type: "Image"
     encoding: "rgb8"
     sample_interval: 5   # Write one sample every 5 messages
-    topic_dir: "color_raw"  # Output data in <output_dir>/color_raw
+    topic_dir: "img/color_raw"  # Output data in <output_dir>/<bag_name>/img/color_raw
   - name: "/camera/color/image_raw/compressed"
     type: "CompressedImage"
     sample_interval: 5   # Write one sample every 5 messages
-    topic_dir: "img/compressed"  # Output data in <output_dir>/img/compressed
+    topic_dir: "img/compressed"
   - name: "/imu_topic"
     type: "IMU"
     sample_interval: 100  # Write one sample every 100 messages
@@ -121,7 +121,7 @@ topics:
   - **name**: The ROS 2 topic name.
   - **type**: The message type (PointCloud2, Image, DepthImage, IMU, GPS, etc.).
   - **sample_interval**: The interval at which messages will be written (e.g., 100 for every 100 messages).
-  - **topic_dir**: The name of the directory where data will be saved. The directory is created in `output_dir`.
+  - **topic_dir**: The name of the directory where data will be saved. The directory is created in `<output_dir>/<bag_name>/`.
 
 ## Usage
 After building and sourcing the workspace, run the `bag_exporter` node using the following command:

--- a/README.md
+++ b/README.md
@@ -87,22 +87,28 @@ topics:
     type: "DepthImage"
     encoding: "16UC1"
     sample_interval: 10  # Write one sample every 10 messages
+    topic_dir: "depth_raw"  # Output data in <output_dir>/depth_raw
   - name: "/camera/color/image_raw"
     type: "Image"
     encoding: "rgb8"
     sample_interval: 5   # Write one sample every 5 messages
+    topic_dir: "color_raw"  # Output data in <output_dir>/color_raw
   - name: "/camera/color/image_raw/compressed"
     type: "CompressedImage"
     sample_interval: 5   # Write one sample every 5 messages
+    topic_dir: "img/compressed"  # Output data in <output_dir>/img/compressed
   - name: "/imu_topic"
     type: "IMU"
     sample_interval: 100  # Write one sample every 100 messages
+    topic_dir: imu
   - name: "/gps_topic"
     type: "GPS"
     sample_interval: 100  # Write one sample every 100 messages
+    topic_dir: gps
   - name: "/lidar/points"
     type: "PointCloud2"
     sample_interval: 10   # Write one sample every 10 messages
+    topic_dir: "lidar"
 ```
 
 ### Parameter Descriptions
@@ -115,6 +121,7 @@ topics:
   - **name**: The ROS 2 topic name.
   - **type**: The message type (PointCloud2, Image, DepthImage, IMU, GPS, etc.).
   - **sample_interval**: The interval at which messages will be written (e.g., 100 for every 100 messages).
+  - **topic_dir**: The name of the directory where data will be saved. The directory is created in `output_dir`.
 
 ## Usage
 After building and sourcing the workspace, run the `bag_exporter` node using the following command:
@@ -137,19 +144,24 @@ topics:
     type: "DepthImage"
     encoding: "16UC1"
     sample_interval: 10
+    topic_dir: "depht_raw"
   - name: "/camera/color/image_raw"
     type: "Image"
     encoding: "rgb8"
     sample_interval: 5
+    topic_dir: "img_raw"
   - name: "/imu_topic"
     type: "IMU"
     sample_interval: 100
+    topic_dir: "imu"
   - name: "/gps_topic"
     type: "GPS"
     sample_interval: 100
+    topic_dir: "gps"
   - name: "/lidar/points"
     type: "PointCloud2"
     sample_interval: 10
+    topic_dir: "lidar"
 ```
 
 ### 2. Running the Exporter

--- a/config/exporter_config.yaml
+++ b/config/exporter_config.yaml
@@ -8,7 +8,7 @@ bag_path: "/path/to/your.bag"
 output_dir: "/path/to/output_directory"
 
 # Storage format for the exported data. Options are "sqlite3" or "mcap"
-storage_id: "sqlite3"
+storage_id: "mcap"
 
 # List of topics to extract from the ROS2 bag
 topics:
@@ -16,36 +16,49 @@ topics:
   - name: "/pointcloud_topic"   # Name of the topic to extract
     type: "PointCloud2"         # Data type of the topic
     sample_interval: 10         # Write one sample every 10 messages
+    topic_dir: "lidar"          # Output data in <output_dir>/lidar
 
   # Configuration for the RGB image topic
   - name: "/rgb_image_topic"    # Name of the topic to extract
     type: "Image"               # Data type of the topic
     encoding: "rgb8"            # Encoding format for the image
     sample_interval: 5          # Write one sample every 5 messages
+    topic_dir: "cam/rgb"        # Output data in <output_dir>/cam/rgb
+
+  # Configuration for the compressed image topic
+  - name: "/compressed_image_topic"  # Name of the topic to extract
+    type: "CompressedImage"          # Data type of the topic
+    sample_interval: 5               # Write one sample every 5 messages
+    topic_dir: "cam/rgb"             # Output data in <output_dir>/cam/rgb
 
   # Configuration for the RGB image topic
-  - name: "/ir_image_topic"    # Name of the topic to extract
-    type: "IRImage"               # Data type of the topic
-    encoding: "mono16"            # Encoding format for the IR image
+  - name: "/ir_image_topic"     # Name of the topic to extract
+    type: "IRImage"             # Data type of the topic
+    encoding: "mono16"          # Encoding format for the IR image
     sample_interval: 5          # Write one sample every 5 messages
+    topic_dir: "cam/ir"         # Output data in <output_dir>/cam/ir
 
   # Configuration for the depth image topic
   - name: "/depth_image_topic"  # Name of the topic to extract
     type: "DepthImage"          # Data type of the topic
     encoding: "16UC1"           # Encoding format for the depth image
     sample_interval: 2          # Write one sample every 2 messages
+    topic_dir: "cam/depth"      # Output data in <output_dir>/cam/depth
 
   # Configuration for the laser scan topic
-  - name: "/laser_scan_topic"       # Name of the topic to extract
-    type: "LaserScan"               # Data type of the topic
-    sample_interval: 5              # Write one sample every 5 messages
+  - name: "/laser_scan_topic"   # Name of the topic to extract
+    type: "LaserScan"           # Data type of the topic
+    sample_interval: 5          # Write one sample every 5 messages
+    topic_dir: "laser"          # Output data in <output_dir>/laser
 
   # Configuration for the IMU (Inertial Measurement Unit) topic
-  - name: "/imu_topic"              # Name of the topic to extract
-    type: "IMU"                     # Data type of the topic
-    sample_interval: 20             # Write one sample every 20 messages
+  - name: "/imu_topic"          # Name of the topic to extract
+    type: "IMU"                 # Data type of the topic
+    sample_interval: 20         # Write one sample every 20 messages
+    topic_dir: "imu"            # Output data in <output_dir>/cam/depth
 
   # Configuration for the GPS topic
-  - name: "/gps_topic"              # Name of the topic to extract
-    type: "GPS"                     # Data type of the topic
-    sample_interval: 1              # Write every message
+  - name: "/gps_topic"          # Name of the topic to extract
+    type: "GPS"                 # Data type of the topic
+    sample_interval: 1          # Write every message
+    topic_dir: "gps"            # Output data in <output_dir>/gps

--- a/config/exporter_config.yaml
+++ b/config/exporter_config.yaml
@@ -16,49 +16,49 @@ topics:
   - name: "/pointcloud_topic"   # Name of the topic to extract
     type: "PointCloud2"         # Data type of the topic
     sample_interval: 10         # Write one sample every 10 messages
-    topic_dir: "lidar"          # Output data in <output_dir>/lidar
+    topic_dir: "lidar"          # Output data in <output_dir>/<bag_name>/lidar
 
   # Configuration for the RGB image topic
   - name: "/rgb_image_topic"    # Name of the topic to extract
     type: "Image"               # Data type of the topic
     encoding: "rgb8"            # Encoding format for the image
     sample_interval: 5          # Write one sample every 5 messages
-    topic_dir: "cam/rgb"        # Output data in <output_dir>/cam/rgb
+    topic_dir: "cam/rgb"        # Output data in <output_dir>/<bag_name>/cam/rgb
 
   # Configuration for the compressed image topic
   - name: "/compressed_image_topic"  # Name of the topic to extract
     type: "CompressedImage"          # Data type of the topic
     sample_interval: 5               # Write one sample every 5 messages
-    topic_dir: "cam/rgb"             # Output data in <output_dir>/cam/rgb
+    topic_dir: "cam/rgb"             # Output data in <output_dir>/<bag_name>/cam/rgb
 
   # Configuration for the RGB image topic
   - name: "/ir_image_topic"     # Name of the topic to extract
     type: "IRImage"             # Data type of the topic
     encoding: "mono16"          # Encoding format for the IR image
     sample_interval: 5          # Write one sample every 5 messages
-    topic_dir: "cam/ir"         # Output data in <output_dir>/cam/ir
+    topic_dir: "cam/ir"         # Output data in <output_dir>/<bag_name>/cam/ir
 
   # Configuration for the depth image topic
   - name: "/depth_image_topic"  # Name of the topic to extract
     type: "DepthImage"          # Data type of the topic
     encoding: "16UC1"           # Encoding format for the depth image
     sample_interval: 2          # Write one sample every 2 messages
-    topic_dir: "cam/depth"      # Output data in <output_dir>/cam/depth
+    topic_dir: "cam/depth"      # Output data in <output_dir>/<bag_name>/cam/depth
 
   # Configuration for the laser scan topic
   - name: "/laser_scan_topic"   # Name of the topic to extract
     type: "LaserScan"           # Data type of the topic
     sample_interval: 5          # Write one sample every 5 messages
-    topic_dir: "laser"          # Output data in <output_dir>/laser
+    topic_dir: "laser"          # Output data in <output_dir>/<bag_name>/laser
 
   # Configuration for the IMU (Inertial Measurement Unit) topic
   - name: "/imu_topic"          # Name of the topic to extract
     type: "IMU"                 # Data type of the topic
     sample_interval: 20         # Write one sample every 20 messages
-    topic_dir: "imu"            # Output data in <output_dir>/cam/depth
+    topic_dir: "imu"            # Output data in <output_dir>/<bag_name>/cam/depth
 
   # Configuration for the GPS topic
   - name: "/gps_topic"          # Name of the topic to extract
     type: "GPS"                 # Data type of the topic
     sample_interval: 1          # Write every message
-    topic_dir: "gps"            # Output data in <output_dir>/gps
+    topic_dir: "gps"            # Output data in <output_dir>/<bag_name>/gps

--- a/config/exporter_config.yaml
+++ b/config/exporter_config.yaml
@@ -23,13 +23,13 @@ topics:
     type: "Image"               # Data type of the topic
     encoding: "rgb8"            # Encoding format for the image
     sample_interval: 5          # Write one sample every 5 messages
-    topic_dir: "cam/rgb"        # Output data in <output_dir>/<bag_name>/cam/rgb
+    topic_dir: "cam/raw"        # Output data in <output_dir>/<bag_name>/cam/raw
 
   # Configuration for the compressed image topic
   - name: "/compressed_image_topic"  # Name of the topic to extract
     type: "CompressedImage"          # Data type of the topic
     sample_interval: 5               # Write one sample every 5 messages
-    topic_dir: "cam/rgb"             # Output data in <output_dir>/<bag_name>/cam/rgb
+    topic_dir: "cam/compressed"      # Output data in <output_dir>/<bag_name>/cam/compressed
 
   # Configuration for the RGB image topic
   - name: "/ir_image_topic"     # Name of the topic to extract
@@ -55,7 +55,7 @@ topics:
   - name: "/imu_topic"          # Name of the topic to extract
     type: "IMU"                 # Data type of the topic
     sample_interval: 20         # Write one sample every 20 messages
-    topic_dir: "imu"            # Output data in <output_dir>/<bag_name>/cam/depth
+    topic_dir: "imu"            # Output data in <output_dir>/<bag_name>/imu
 
   # Configuration for the GPS topic
   - name: "/gps_topic"          # Name of the topic to extract

--- a/include/rosbag2_exporter/bag_exporter.hpp
+++ b/include/rosbag2_exporter/bag_exporter.hpp
@@ -53,6 +53,7 @@ struct TopicConfig
   MessageType type;
   std::string encoding;
   int sample_interval;
+  std::string topic_dir;
 };
 
 struct Handler

--- a/include/rosbag2_exporter/handlers/compressed_image_handler.hpp
+++ b/include/rosbag2_exporter/handlers/compressed_image_handler.hpp
@@ -27,10 +27,10 @@ class CompressedImageHandler : public BaseHandler
 {
 public:
 
-  CompressedImageHandler(const std::string & output_dir,
+  CompressedImageHandler(const std::string & topic_dir,
                const std::string & encoding,
                rclcpp::Logger logger)
-  : BaseHandler(logger), output_dir_(output_dir)
+  : BaseHandler(logger), topic_dir_(topic_dir)
   {}
 
   // Handle compressed image messages
@@ -60,19 +60,13 @@ public:
                  << std::setw(9) << std::setfill('0') << compressed_img.header.stamp.nanosec;
     std::string timestamp = ss_timestamp.str();
 
-    std::string sanitized_topic = topic;
-    if (!sanitized_topic.empty() && sanitized_topic[0] == '/') {
-      sanitized_topic = sanitized_topic.substr(1);
-    }
-
     // Create the full file path
-    std::string filepath = output_dir_ + "/" + sanitized_topic + "/" + timestamp + extension;
+    std::string filepath = topic_dir_ + "/" + timestamp + extension;
 
     // Ensure the directory exists, create if necessary
-    std::filesystem::path dir_path = output_dir_ + "/" + sanitized_topic;
-    if (!std::filesystem::exists(dir_path)) {
-      RCLCPP_INFO(logger_, "Creating directory: %s", dir_path.c_str());
-      std::filesystem::create_directories(dir_path);
+    if (!std::filesystem::exists(topic_dir_)) {
+      RCLCPP_INFO(logger_, "Creating directory: %s", topic_dir_.c_str());
+      std::filesystem::create_directories(topic_dir_);
     }
 
     // Save the compressed image data directly to file
@@ -89,7 +83,7 @@ public:
 
 
 private:
-  std::string output_dir_;
+  std::string topic_dir_;
   // Defined to comply with class parent but not needed
   std::string encoding_; 
 

--- a/include/rosbag2_exporter/handlers/depth_image_handler.hpp
+++ b/include/rosbag2_exporter/handlers/depth_image_handler.hpp
@@ -21,10 +21,10 @@ class DepthImageHandler : public BaseHandler
 {
 public:
   // Constructor to accept logger and encoding with default fallback
-  DepthImageHandler(const std::string & output_dir,
+  DepthImageHandler(const std::string & topic_dir,
                    const std::string & encoding,
                    rclcpp::Logger logger)
-  : BaseHandler(logger), output_dir_(output_dir)
+  : BaseHandler(logger), topic_dir_(topic_dir)
   {
     // Validate or set default encoding if not provided
     if (encoding.empty()) {
@@ -67,20 +67,13 @@ public:
                 << std::setw(9) << std::setfill('0') << img.header.stamp.nanosec;
     std::string timestamp = ss_timestamp.str();
 
-    // Sanitize the topic name by removing the leading '/'
-    std::string sanitized_topic = topic;
-    if (!sanitized_topic.empty() && sanitized_topic[0] == '/') {
-      sanitized_topic = sanitized_topic.substr(1);
-    }
-
     // Create the full file path with '.png' as the extension
-    std::string filepath = output_dir_ + "/" + sanitized_topic + "/" + timestamp + ".png";
+    std::string filepath = topic_dir_ + "/" + timestamp + ".png";
 
     // Ensure the directory exists, create if necessary
-    std::filesystem::path dir_path = output_dir_ + "/" + sanitized_topic;
-    if (!std::filesystem::exists(dir_path)) {
-      RCLCPP_INFO(logger_, "Creating directory: %s", dir_path.c_str());
-      std::filesystem::create_directories(dir_path);
+    if (!std::filesystem::exists(topic_dir_)) {
+      RCLCPP_INFO(logger_, "Creating directory: %s", topic_dir_.c_str());
+      std::filesystem::create_directories(topic_dir_);
     }
 
     // Normalize depth image for better visualization if needed
@@ -100,7 +93,7 @@ public:
   }
 
 private:
-  std::string output_dir_;
+  std::string topic_dir_;
   std::string encoding_;
 };
 

--- a/include/rosbag2_exporter/handlers/gps_handler.hpp
+++ b/include/rosbag2_exporter/handlers/gps_handler.hpp
@@ -20,8 +20,8 @@ class GPSHandler : public BaseHandler
 {
 public:
   // Constructor to accept logger
-  GPSHandler(const std::string & output_dir, rclcpp::Logger logger)
-  : BaseHandler(logger), output_dir_(output_dir)
+  GPSHandler(const std::string & topic_dir, rclcpp::Logger logger)
+  : BaseHandler(logger), topic_dir_(topic_dir)
   {}
 
   void process_message(const rclcpp::SerializedMessage & serialized_msg,
@@ -39,20 +39,13 @@ public:
                 << std::setw(9) << std::setfill('0') << gps_data.header.stamp.nanosec;
     std::string timestamp = ss_timestamp.str();
 
-    // Sanitize the topic name by removing the leading '/'
-    std::string sanitized_topic = topic;
-    if (!sanitized_topic.empty() && sanitized_topic[0] == '/') {
-      sanitized_topic = sanitized_topic.substr(1);
-    }
-
     // Create the full file path with '.csv' as the extension
-    std::string filepath = output_dir_ + "/" + sanitized_topic + "/" + timestamp + ".csv";
+    std::string filepath = topic_dir_ + "/" + timestamp + ".csv";
 
     // Ensure the directory exists, create if necessary
-    std::filesystem::path dir_path = output_dir_ + "/" + sanitized_topic;
-    if (!std::filesystem::exists(dir_path)) {
-      RCLCPP_INFO(logger_, "Creating directory: %s", dir_path.c_str());
-      std::filesystem::create_directories(dir_path);
+    if (!std::filesystem::exists(topic_dir_)) {
+      RCLCPP_INFO(logger_, "Creating directory: %s", topic_dir_.c_str());
+      std::filesystem::create_directories(topic_dir_);
     }
 
     // Open file and write GPS data as CSV
@@ -78,7 +71,7 @@ public:
   }
 
 private:
-  std::string output_dir_;
+  std::string topic_dir_;
 };
 
 }  // namespace rosbag2_exporter

--- a/include/rosbag2_exporter/handlers/image_handler.hpp
+++ b/include/rosbag2_exporter/handlers/image_handler.hpp
@@ -30,10 +30,10 @@ class ImageHandler : public BaseHandler
 {
 public:
   // Constructor to accept logger and encoding, with a default value for encoding
-  ImageHandler(const std::string & output_dir,
+  ImageHandler(const std::string & topic_dir,
                const std::string & encoding,
                rclcpp::Logger logger)
-  : BaseHandler(logger), output_dir_(output_dir)
+  : BaseHandler(logger), topic_dir_(topic_dir)
   {
     // Validate or set default encoding if not provided
     if (encoding.empty()) {
@@ -90,7 +90,7 @@ public:
   }
 
 private:
-  std::string output_dir_;
+  std::string topic_dir_;
   std::string encoding_;
 
   // Helper function to save uncompressed images
@@ -105,20 +105,13 @@ private:
     // Determine file extension based on encoding
     std::string extension = ".png";  // Default to PNG
 
-    // Sanitize the topic name by removing the leading '/'
-    std::string sanitized_topic = topic;
-    if (!sanitized_topic.empty() && sanitized_topic[0] == '/') {
-      sanitized_topic = sanitized_topic.substr(1);
-    }
-
     // Create the full file path
-    std::string filepath = output_dir_ + "/" + sanitized_topic + "/" + timestamp_str + extension;
+    std::string filepath = topic_dir_ + timestamp_str + extension;
 
     // Ensure the directory exists, create if necessary
-    std::filesystem::path dir_path = output_dir_ + "/" + sanitized_topic;
-    if (!std::filesystem::exists(dir_path)) {
-      RCLCPP_INFO(logger_, "Creating directory: %s", dir_path.c_str());
-      std::filesystem::create_directories(dir_path);
+    if (!std::filesystem::exists(topic_dir_)) {
+      RCLCPP_INFO(logger_, "Creating directory: %s", topic_dir_.c_str());
+      std::filesystem::create_directories(topic_dir_);
     }
 
     // Write the image to disk

--- a/include/rosbag2_exporter/handlers/imu_handler.hpp
+++ b/include/rosbag2_exporter/handlers/imu_handler.hpp
@@ -20,8 +20,8 @@ class IMUHandler : public BaseHandler
 {
 public:
   // Constructor to accept logger
-  IMUHandler(const std::string & output_dir, rclcpp::Logger logger)
-  : BaseHandler(logger), output_dir_(output_dir)
+  IMUHandler(const std::string & topic_dir, rclcpp::Logger logger)
+  : BaseHandler(logger), topic_dir_(topic_dir)
   {}
 
   void process_message(const rclcpp::SerializedMessage & serialized_msg,
@@ -39,20 +39,13 @@ public:
                 << std::setw(9) << std::setfill('0') << imu_data.header.stamp.nanosec;
     std::string timestamp = ss_timestamp.str();
 
-    // Sanitize the topic name by removing the leading '/'
-    std::string sanitized_topic = topic;
-    if (!sanitized_topic.empty() && sanitized_topic[0] == '/') {
-      sanitized_topic = sanitized_topic.substr(1);
-    }
-
     // Create the full file path with '.csv' as the extension
-    std::string filepath = output_dir_ + "/" + sanitized_topic + "/" + timestamp + ".csv";
+    std::string filepath = topic_dir_ + "/" + timestamp + ".csv";
 
     // Ensure the directory exists, create if necessary
-    std::filesystem::path dir_path = output_dir_ + "/" + sanitized_topic;
-    if (!std::filesystem::exists(dir_path)) {
-      RCLCPP_INFO(logger_, "Creating directory: %s", dir_path.c_str());
-      std::filesystem::create_directories(dir_path);
+    if (!std::filesystem::exists(topic_dir_)) {
+      RCLCPP_INFO(logger_, "Creating directory: %s", topic_dir_.c_str());
+      std::filesystem::create_directories(topic_dir_);
     }
 
     // Open file and write IMU data as CSV
@@ -78,7 +71,7 @@ public:
   }
 
 private:
-  std::string output_dir_;
+  std::string topic_dir_;
 };
 
 }  // namespace rosbag2_exporter

--- a/include/rosbag2_exporter/handlers/ir_image_handler.hpp
+++ b/include/rosbag2_exporter/handlers/ir_image_handler.hpp
@@ -21,10 +21,10 @@ class IRImageHandler : public BaseHandler
 {
 public:
   // Constructor to accept logger and encoding with a default fallback for encoding
-  IRImageHandler(const std::string & output_dir,
+  IRImageHandler(const std::string & topic_dir,
                 const std::string & encoding,
                 rclcpp::Logger logger)
-  : BaseHandler(logger), output_dir_(output_dir)
+  : BaseHandler(logger), topic_dir_(topic_dir)
   {
     // Validate or set default encoding if not provided
     if (encoding.empty()) {
@@ -67,20 +67,13 @@ public:
                 << std::setw(9) << std::setfill('0') << img.header.stamp.nanosec;
     std::string timestamp = ss_timestamp.str();
 
-    // Sanitize the topic name by removing the leading '/'
-    std::string sanitized_topic = topic;
-    if (!sanitized_topic.empty() && sanitized_topic[0] == '/') {
-      sanitized_topic = sanitized_topic.substr(1);
-    }
-
     // Create the full file path with '.png' as the extension
-    std::string filepath = output_dir_ + "/" + sanitized_topic + "/" + timestamp + ".png";
+    std::string filepath = topic_dir_ + "/" + "/" + timestamp + ".png";
 
     // Ensure the directory exists, create if necessary
-    std::filesystem::path dir_path = output_dir_ + "/" + sanitized_topic;
-    if (!std::filesystem::exists(dir_path)) {
-      RCLCPP_INFO(logger_, "Creating directory: %s", dir_path.c_str());
-      std::filesystem::create_directories(dir_path);
+    if (!std::filesystem::exists(topic_dir_)) {
+      RCLCPP_INFO(logger_, "Creating directory: %s", topic_dir_.c_str());
+      std::filesystem::create_directories(topic_dir_);
     }
 
     // Write the image to disk
@@ -92,7 +85,7 @@ public:
   }
 
 private:
-  std::string output_dir_;
+  std::string topic_dir_;
   std::string encoding_;
 };
 

--- a/include/rosbag2_exporter/handlers/laser_scan_handler.hpp
+++ b/include/rosbag2_exporter/handlers/laser_scan_handler.hpp
@@ -20,8 +20,8 @@ class LaserScanHandler : public BaseHandler
 {
 public:
   // Constructor to accept logger
-  LaserScanHandler(const std::string & output_dir, rclcpp::Logger logger)
-  : BaseHandler(logger), output_dir_(output_dir)
+  LaserScanHandler(const std::string & topic_dir, rclcpp::Logger logger)
+  : BaseHandler(logger), topic_dir_(topic_dir)
   {}
 
   void process_message(const rclcpp::SerializedMessage & serialized_msg,
@@ -39,20 +39,13 @@ public:
                 << std::setw(9) << std::setfill('0') << laser_scan.header.stamp.nanosec;
     std::string timestamp = ss_timestamp.str();
 
-    // Sanitize the topic name by removing the leading '/'
-    std::string sanitized_topic = topic;
-    if (!sanitized_topic.empty() && sanitized_topic[0] == '/') {
-      sanitized_topic = sanitized_topic.substr(1);
-    }
-
     // Create the full file path with '.csv' as the extension
-    std::string filepath = output_dir_ + "/" + sanitized_topic + "/" + timestamp + ".csv";
+    std::string filepath = topic_dir_ + "/" + timestamp + ".csv";
 
     // Ensure the directory exists, create if necessary
-    std::filesystem::path dir_path = output_dir_ + "/" + sanitized_topic;
-    if (!std::filesystem::exists(dir_path)) {
-      RCLCPP_INFO(logger_, "Creating directory: %s", dir_path.c_str());
-      std::filesystem::create_directories(dir_path);
+    if (!std::filesystem::exists(topic_dir_)) {
+      RCLCPP_INFO(logger_, "Creating directory: %s", topic_dir_.c_str());
+      std::filesystem::create_directories(topic_dir_);
     }
 
     // Open file and write LaserScan data as CSV
@@ -95,7 +88,7 @@ public:
   }
 
 private:
-  std::string output_dir_;
+  std::string topic_dir_;
 };
 
 }  // namespace rosbag2_exporter

--- a/include/rosbag2_exporter/handlers/pointcloud_handler.hpp
+++ b/include/rosbag2_exporter/handlers/pointcloud_handler.hpp
@@ -22,8 +22,8 @@ class PointCloudHandler : public BaseHandler
 {
 public:
   // Constructor to accept logger
-  PointCloudHandler(const std::string & output_dir, rclcpp::Logger logger)
-  : BaseHandler(logger), output_dir_(output_dir)
+  PointCloudHandler(const std::string & topic_dir, rclcpp::Logger logger)
+  : BaseHandler(logger), topic_dir_(topic_dir)
   {}
 
   void process_message(const rclcpp::SerializedMessage & serialized_msg,
@@ -56,7 +56,7 @@ public:
   }
 
 private:
-  std::string output_dir_;
+  std::string topic_dir_;
 
   // Templated function to save point cloud to file
   template<typename PointT>
@@ -75,11 +75,10 @@ private:
     RCLCPP_INFO(logger_, "Processing PointCloud2 message at timestamp: %s #%zu", timestamp.c_str(), index);
 
     // Ensure the directory exists
-    std::string topic_dir = output_dir_ + "/" + topic.substr(1);
-    std::filesystem::create_directories(topic_dir);
+    std::filesystem::create_directories(topic_dir_);
 
     // Construct filename
-    std::string filename = topic_dir + "/" + timestamp + ".pcd";
+    std::string filename = topic_dir_ + "/" + timestamp + ".pcd";
 
     // Save the point cloud
     if (pcl::io::savePCDFileBinary(filename, *cloud) == -1) {

--- a/src/bag_exporter.cpp
+++ b/src/bag_exporter.cpp
@@ -51,6 +51,7 @@ void BagExporter::load_configuration(const std::string & config_file)
       TopicConfig tc;
       tc.name = topic["name"].as<std::string>();
       std::string type = topic["type"].as<std::string>();
+      tc.topic_dir = topic["topic_dir"].as<std::string>();
 
       tc.sample_interval = topic["sample_interval"] ? topic["sample_interval"].as<int>() : 1;  // Default to 1 (write every message)
 
@@ -89,40 +90,33 @@ void BagExporter::load_configuration(const std::string & config_file)
 void BagExporter::setup_handlers()
 {
   for (const auto & topic : topics_) {
-    // Ensure topic name starts with '/'
-    std::string sanitized_topic = topic.name;
-    if (sanitized_topic.empty() || sanitized_topic[0] != '/') {
-      sanitized_topic = "/" + sanitized_topic;
-    }
-
     // Create directory for each topic
-    std::string topic_dir = output_dir_ + "/" + sanitized_topic.substr(1); // Remove leading '/'
-    std::filesystem::create_directories(topic_dir);
+    std::string abs_topic_dir = output_dir_ + "/" + topic.topic_dir;
 
     // Initialize handler based on message type
     if (topic.type == MessageType::PointCloud2) {
-      auto handler = std::make_shared<PointCloudHandler>(topic_dir, this->get_logger());
+      auto handler = std::make_shared<PointCloudHandler>(abs_topic_dir, this->get_logger());
       handlers_[topic.name] = Handler{handler, 0};
     } else if (topic.type == MessageType::Image) {
-      auto handler = std::make_shared<ImageHandler>(topic_dir, topic.encoding, this->get_logger());
+      auto handler = std::make_shared<ImageHandler>(abs_topic_dir, topic.encoding, this->get_logger());
       handlers_[topic.name] = Handler{handler, 0};
     } else if (topic.type == MessageType::CompressedImage) {
-      auto handler = std::make_shared<CompressedImageHandler>(topic_dir, topic.encoding, this->get_logger());
+      auto handler = std::make_shared<CompressedImageHandler>(abs_topic_dir, topic.encoding, this->get_logger());
       handlers_[topic.name] = Handler{handler, 0};
     } else if (topic.type == MessageType::DepthImage) {
-      auto handler = std::make_shared<DepthImageHandler>(topic_dir, topic.encoding, this->get_logger());
+      auto handler = std::make_shared<DepthImageHandler>(abs_topic_dir, topic.encoding, this->get_logger());
       handlers_[topic.name] = Handler{handler, 0};
     } else if (topic.type == MessageType::IRImage) {
-      auto handler = std::make_shared<IRImageHandler>(topic_dir, topic.encoding, this->get_logger());
+      auto handler = std::make_shared<IRImageHandler>(abs_topic_dir, topic.encoding, this->get_logger());
       handlers_[topic.name] = Handler{handler, 0};
     } else if (topic.type == MessageType::IMU) {
-      auto handler = std::make_shared<IMUHandler>(topic_dir, this->get_logger());
+      auto handler = std::make_shared<IMUHandler>(abs_topic_dir, this->get_logger());
       handlers_[topic.name] = Handler{handler, 0};
     } else if (topic.type == MessageType::GPS) {
-      auto handler = std::make_shared<GPSHandler>(topic_dir, this->get_logger());
+      auto handler = std::make_shared<GPSHandler>(abs_topic_dir, this->get_logger());
       handlers_[topic.name] = Handler{handler, 0};
     } else if (topic.type == MessageType::LaserScan) {
-      auto handler = std::make_shared<LaserScanHandler>(topic_dir, this->get_logger());
+      auto handler = std::make_shared<LaserScanHandler>(abs_topic_dir, this->get_logger());
       handlers_[topic.name] = Handler{handler, 0};
     } else {
       RCLCPP_WARN(this->get_logger(), "Unsupported message type for topic '%s'. Skipping.", topic.name.c_str());

--- a/src/bag_exporter.cpp
+++ b/src/bag_exporter.cpp
@@ -89,9 +89,12 @@ void BagExporter::load_configuration(const std::string & config_file)
 
 void BagExporter::setup_handlers()
 {
+  // Extract base name from rosbag file
+  std::string rosbag_base_name = std::filesystem::path(bag_path_).stem().string();
+  
   for (const auto & topic : topics_) {
     // Create directory for each topic
-    std::string abs_topic_dir = output_dir_ + "/" + topic.topic_dir;
+    std::string abs_topic_dir = output_dir_ + "/" + rosbag_base_name + "/" + topic.topic_dir;
 
     // Initialize handler based on message type
     if (topic.type == MessageType::PointCloud2) {


### PR DESCRIPTION
   - Fix double path directory generation issue
      - Add `topic_dir` param to define the directory tree of
        a topic relative to `output_dir` instead of resolving a path
        from a topic
      - Construct data's absolute directory path from `setup_handlers()` instead
      - Use rosbag name to create a directory to place the data
         - `absolute_topic_dir = output_dir + <robsag_name> + topic_dir `
      - Fix handlers objects to receive data's absolute directory path
        and avoid modifying it
      - Rename `output_dir` handler member to `topic_dir_` to maintain consistency and improve readability