### PR TITLE
Add metadata generation based on sensor timestamps

### DIFF
--- a/config/exporter_config.yaml
+++ b/config/exporter_config.yaml
@@ -12,7 +12,8 @@ storage_id: "mcap"
 
 # List of topics to extract from the ROS2 bag
 topics:
-  # Configuration for the point cloud topic
+  # The timestamp of the first topic in this list will be used as the reference for sensor synchronisation
+  # Configuration for the point cloud topic. 
   - name: "/pointcloud_topic"   # Name of the topic to extract
     type: "PointCloud2"         # Data type of the topic
     sample_interval: 10         # Write one sample every 10 messages

--- a/include/rosbag2_exporter/bag_exporter.hpp
+++ b/include/rosbag2_exporter/bag_exporter.hpp
@@ -71,10 +71,12 @@ private:
   void load_configuration(const std::string & config_file);
   void setup_handlers();
   void export_bag();
+  void create_metadata_file();
 
   std::string bag_path_;
   std::string output_dir_;
   std::string storage_id_;
+  std::string rosbag_base_name_;
   std::vector<TopicConfig> topics_;
   std::map<std::string, Handler> handlers_;
 };

--- a/include/rosbag2_exporter/handlers/base_handler.hpp
+++ b/include/rosbag2_exporter/handlers/base_handler.hpp
@@ -7,12 +7,28 @@
 #define ROSBAG2_EXPORTER__HANDLERS__BASE_HANDLER_HPP_
 
 #include <string>
+#include <vector>
 #include <rclcpp/serialization.hpp>
 #include <rclcpp/serialized_message.hpp>
 #include <rclcpp/logger.hpp>
+#include "builtin_interfaces/msg/time.hpp"
+
 
 namespace rosbag2_exporter
 {
+
+struct DataMeta
+{
+  std::string data_path;
+  builtin_interfaces::msg::Time timestamp;
+  size_t global_id;
+
+  DataMeta() = default;
+
+  DataMeta(std::string _data_path, builtin_interfaces::msg::Time _timestamp, size_t _global_id)
+      : data_path(std::move(_data_path)), timestamp(std::move(_timestamp)), global_id(std::move(_global_id)) {}
+
+};
 
 class BaseHandler
 {
@@ -23,6 +39,8 @@ public:
   virtual void process_message(const rclcpp::SerializedMessage & serialized_msg,
                                const std::string & topic,
                                size_t index) = 0;
+public:
+  std::vector<DataMeta> data_meta_vec_;
 
 protected:
   rclcpp::Logger logger_;

--- a/include/rosbag2_exporter/handlers/compressed_image_handler.hpp
+++ b/include/rosbag2_exporter/handlers/compressed_image_handler.hpp
@@ -65,7 +65,6 @@ public:
 
     // Ensure the directory exists, create if necessary
     if (!std::filesystem::exists(topic_dir_)) {
-      RCLCPP_INFO(logger_, "Creating directory: %s", topic_dir_.c_str());
       std::filesystem::create_directories(topic_dir_);
     }
 

--- a/include/rosbag2_exporter/handlers/compressed_image_handler.hpp
+++ b/include/rosbag2_exporter/handlers/compressed_image_handler.hpp
@@ -80,7 +80,7 @@ public:
 
     data_meta_vec_.push_back(DataMeta{filepath, compressed_img.header.stamp, index});
 
-    RCLCPP_INFO(logger_, "Successfully wrote compressed image to %s", filepath.c_str());
+    RCLCPP_DEBUG(logger_, "Successfully wrote compressed image to %s", filepath.c_str());
   }
 
 

--- a/include/rosbag2_exporter/handlers/compressed_image_handler.hpp
+++ b/include/rosbag2_exporter/handlers/compressed_image_handler.hpp
@@ -78,6 +78,8 @@ public:
     outfile.write(reinterpret_cast<const char*>(compressed_img.data.data()), compressed_img.data.size());
     outfile.close();
 
+    data_meta_vec_.push_back(DataMeta{filepath, compressed_img.header.stamp, index});
+
     RCLCPP_INFO(logger_, "Successfully wrote compressed image to %s", filepath.c_str());
   }
 

--- a/include/rosbag2_exporter/handlers/depth_image_handler.hpp
+++ b/include/rosbag2_exporter/handlers/depth_image_handler.hpp
@@ -88,7 +88,8 @@ public:
     if (!cv::imwrite(filepath, depth_image)) {
       RCLCPP_ERROR(logger_, "Failed to write depth image to %s", filepath.c_str());
     } else {
-      RCLCPP_INFO(logger_, "Successfully wrote depth image to %s", filepath.c_str());
+        data_meta_vec_.push_back(DataMeta{filepath, img.header.stamp, index});
+        RCLCPP_INFO(logger_, "Successfully wrote depth image to %s", filepath.c_str());
     }
   }
 

--- a/include/rosbag2_exporter/handlers/depth_image_handler.hpp
+++ b/include/rosbag2_exporter/handlers/depth_image_handler.hpp
@@ -72,7 +72,6 @@ public:
 
     // Ensure the directory exists, create if necessary
     if (!std::filesystem::exists(topic_dir_)) {
-      RCLCPP_INFO(logger_, "Creating directory: %s", topic_dir_.c_str());
       std::filesystem::create_directories(topic_dir_);
     }
 

--- a/include/rosbag2_exporter/handlers/depth_image_handler.hpp
+++ b/include/rosbag2_exporter/handlers/depth_image_handler.hpp
@@ -89,7 +89,7 @@ public:
       RCLCPP_ERROR(logger_, "Failed to write depth image to %s", filepath.c_str());
     } else {
         data_meta_vec_.push_back(DataMeta{filepath, img.header.stamp, index});
-        RCLCPP_INFO(logger_, "Successfully wrote depth image to %s", filepath.c_str());
+        RCLCPP_DEBUG(logger_, "Successfully wrote depth image to %s", filepath.c_str());
     }
   }
 

--- a/include/rosbag2_exporter/handlers/gps_handler.hpp
+++ b/include/rosbag2_exporter/handlers/gps_handler.hpp
@@ -44,7 +44,6 @@ public:
 
     // Ensure the directory exists, create if necessary
     if (!std::filesystem::exists(topic_dir_)) {
-      RCLCPP_INFO(logger_, "Creating directory: %s", topic_dir_.c_str());
       std::filesystem::create_directories(topic_dir_);
     }
 

--- a/include/rosbag2_exporter/handlers/gps_handler.hpp
+++ b/include/rosbag2_exporter/handlers/gps_handler.hpp
@@ -67,7 +67,7 @@ public:
 
     outfile.close();
 
-    RCLCPP_INFO(logger_, "Successfully wrote GPS data to %s", filepath.c_str());
+    RCLCPP_DEBUG(logger_, "Successfully wrote GPS data to %s", filepath.c_str());
   }
 
 private:

--- a/include/rosbag2_exporter/handlers/image_handler.hpp
+++ b/include/rosbag2_exporter/handlers/image_handler.hpp
@@ -110,7 +110,6 @@ private:
 
     // Ensure the directory exists, create if necessary
     if (!std::filesystem::exists(topic_dir_)) {
-      RCLCPP_INFO(logger_, "Creating directory: %s", topic_dir_.c_str());
       std::filesystem::create_directories(topic_dir_);
     }
 

--- a/include/rosbag2_exporter/handlers/image_handler.hpp
+++ b/include/rosbag2_exporter/handlers/image_handler.hpp
@@ -119,7 +119,7 @@ private:
       RCLCPP_ERROR(logger_, "Failed to write image to %s", filepath.c_str());
     } else {
       data_meta_vec_.push_back(DataMeta{filepath, timestamp, index});
-      RCLCPP_INFO(logger_, "Successfully wrote image to %s", filepath.c_str());
+      RCLCPP_DEBUG(logger_, "Successfully wrote image to %s", filepath.c_str());
     }
   }
 };

--- a/include/rosbag2_exporter/handlers/image_handler.hpp
+++ b/include/rosbag2_exporter/handlers/image_handler.hpp
@@ -86,7 +86,7 @@ public:
       }
 
       // Save the image to file
-      save_image(cv_ptr->image, topic, img.header.stamp);
+      save_image(cv_ptr->image, topic, img.header.stamp, index);
   }
 
 private:
@@ -94,7 +94,7 @@ private:
   std::string encoding_;
 
   // Helper function to save uncompressed images
-  void save_image(const cv::Mat& image, const std::string& topic, const builtin_interfaces::msg::Time& timestamp)
+  void save_image(const cv::Mat& image, const std::string& topic, const builtin_interfaces::msg::Time& timestamp, size_t& index)
   {
     // Create a timestamped filename
     std::stringstream ss_timestamp;
@@ -118,6 +118,7 @@ private:
     if (!cv::imwrite(filepath, image)) {
       RCLCPP_ERROR(logger_, "Failed to write image to %s", filepath.c_str());
     } else {
+      data_meta_vec_.push_back(DataMeta{filepath, timestamp, index});
       RCLCPP_INFO(logger_, "Successfully wrote image to %s", filepath.c_str());
     }
   }

--- a/include/rosbag2_exporter/handlers/imu_handler.hpp
+++ b/include/rosbag2_exporter/handlers/imu_handler.hpp
@@ -67,7 +67,7 @@ public:
 
     outfile.close();
 
-    RCLCPP_INFO(logger_, "Successfully wrote IMU data to %s", filepath.c_str());
+    RCLCPP_DEBUG(logger_, "Successfully wrote IMU data to %s", filepath.c_str());
   }
 
 private:

--- a/include/rosbag2_exporter/handlers/imu_handler.hpp
+++ b/include/rosbag2_exporter/handlers/imu_handler.hpp
@@ -44,7 +44,6 @@ public:
 
     // Ensure the directory exists, create if necessary
     if (!std::filesystem::exists(topic_dir_)) {
-      RCLCPP_INFO(logger_, "Creating directory: %s", topic_dir_.c_str());
       std::filesystem::create_directories(topic_dir_);
     }
 

--- a/include/rosbag2_exporter/handlers/ir_image_handler.hpp
+++ b/include/rosbag2_exporter/handlers/ir_image_handler.hpp
@@ -80,7 +80,8 @@ public:
     if (!cv::imwrite(filepath, cv_ptr->image)) {
       RCLCPP_ERROR(logger_, "Failed to write IR image to %s", filepath.c_str());
     } else {
-      RCLCPP_INFO(logger_, "Successfully wrote IR image to %s", filepath.c_str());
+        data_meta_vec_.push_back(DataMeta{filepath, img.header.stamp, index});
+        RCLCPP_INFO(logger_, "Successfully wrote IR image to %s", filepath.c_str());
     }
   }
 

--- a/include/rosbag2_exporter/handlers/ir_image_handler.hpp
+++ b/include/rosbag2_exporter/handlers/ir_image_handler.hpp
@@ -72,7 +72,6 @@ public:
 
     // Ensure the directory exists, create if necessary
     if (!std::filesystem::exists(topic_dir_)) {
-      RCLCPP_INFO(logger_, "Creating directory: %s", topic_dir_.c_str());
       std::filesystem::create_directories(topic_dir_);
     }
 

--- a/include/rosbag2_exporter/handlers/ir_image_handler.hpp
+++ b/include/rosbag2_exporter/handlers/ir_image_handler.hpp
@@ -81,7 +81,7 @@ public:
       RCLCPP_ERROR(logger_, "Failed to write IR image to %s", filepath.c_str());
     } else {
         data_meta_vec_.push_back(DataMeta{filepath, img.header.stamp, index});
-        RCLCPP_INFO(logger_, "Successfully wrote IR image to %s", filepath.c_str());
+        RCLCPP_DEBUG(logger_, "Successfully wrote IR image to %s", filepath.c_str());
     }
   }
 

--- a/include/rosbag2_exporter/handlers/laser_scan_handler.hpp
+++ b/include/rosbag2_exporter/handlers/laser_scan_handler.hpp
@@ -84,7 +84,7 @@ public:
     }
 
     outfile.close();
-    RCLCPP_INFO(logger_, "Successfully wrote LaserScan data to %s", filepath.c_str());
+    RCLCPP_DEBUG(logger_, "Successfully wrote LaserScan data to %s", filepath.c_str());
   }
 
 private:

--- a/include/rosbag2_exporter/handlers/laser_scan_handler.hpp
+++ b/include/rosbag2_exporter/handlers/laser_scan_handler.hpp
@@ -43,8 +43,7 @@ public:
     std::string filepath = topic_dir_ + "/" + timestamp + ".csv";
 
     // Ensure the directory exists, create if necessary
-    if (!std::filesystem::exists(topic_dir_)) {
-      RCLCPP_INFO(logger_, "Creating directory: %s", topic_dir_.c_str());
+    if (!std::filesystem::exists(topic_dir_)) {  
       std::filesystem::create_directories(topic_dir_);
     }
 

--- a/include/rosbag2_exporter/handlers/pointcloud_handler.hpp
+++ b/include/rosbag2_exporter/handlers/pointcloud_handler.hpp
@@ -72,9 +72,6 @@ private:
                  << std::setw(9) << std::setfill('0') << pc2.header.stamp.nanosec;
     std::string timestamp = ss_timestamp.str();
 
-    // Log the processing
-    RCLCPP_INFO(logger_, "Processing PointCloud2 message at timestamp: %s #%zu", timestamp.c_str(), index);
-
     // Ensure the directory exists
     std::filesystem::create_directories(topic_dir_);
 
@@ -87,6 +84,8 @@ private:
     if (pcl::io::savePCDFileBinary(filename, *cloud) == -1) {
       RCLCPP_ERROR(logger_, "Failed to write PCD file to %s", filename.c_str());
     }
+
+    RCLCPP_DEBUG(logger_, "Successfully wrote PointCloud2 message to : %s", filename.c_str());
   }
 };
 

--- a/include/rosbag2_exporter/handlers/pointcloud_handler.hpp
+++ b/include/rosbag2_exporter/handlers/pointcloud_handler.hpp
@@ -53,6 +53,7 @@ public:
       pcl::fromROSMsg(pc2, *cloud);
       save_pointcloud_to_file<pcl::PointXYZ>(cloud, topic, pc2, index);  // Explicitly specify template type
     }
+
   }
 
 private:
@@ -79,6 +80,8 @@ private:
 
     // Construct filename
     std::string filename = topic_dir_ + "/" + timestamp + ".pcd";
+
+    data_meta_vec_.push_back(DataMeta{filename, pc2.header.stamp, index});
 
     // Save the point cloud
     if (pcl::io::savePCDFileBinary(filename, *cloud) == -1) {

--- a/include/rosbag2_exporter/utils.hpp
+++ b/include/rosbag2_exporter/utils.hpp
@@ -62,6 +62,36 @@ size_t find_closest_timestamp(const std::vector<DataMeta>& target_vector,
     return closest_index;
 }
 
+// Helper to  produce a stdout progress bar
+void print_progress(int percentage) {
+    // Static is safe as this runs only until 100% is reached 
+    static int last_percentage = -1;
+
+    // Never exceeds 100%
+    if (percentage > 100) percentage = 100;
+    // Prevent duplicate prints 
+    if (percentage == last_percentage) return; 
+
+    last_percentage = percentage;
+
+    int width = 50;
+    int pos = width * percentage / 100;
+
+    std::cout << "\r\t\t\t\t\t\t [";
+    for (int i = 0; i < width; ++i) {
+        if (i < pos) std::cout << "=";
+        else if (i == pos) std::cout << ">";
+        else std::cout << " ";
+    }
+
+    std::cout << "] " << percentage << "%" << std::flush;
+
+    // Print a newline once at 100%
+    if (percentage >= 100)
+        std::cout << std::endl;  
+}
+
+
 } // namespace rosbag2_exporter
 
 #endif // UTILS_HPP

--- a/include/rosbag2_exporter/utils.hpp
+++ b/include/rosbag2_exporter/utils.hpp
@@ -1,0 +1,67 @@
+#ifndef UTILS_HPP
+#define UTILS_HPP
+
+#include <string>
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <vector>
+
+#include "rosbag2_exporter/handlers/base_handler.hpp"
+#include "builtin_interfaces/msg/time.hpp"
+
+namespace rosbag2_exporter {
+
+std::string get_cam_name(const std::string& path) {
+    const std::string prefix = "/sensor/camera/";
+    size_t start = path.find(prefix);
+    if (start == std::string::npos) {
+        return ""; // Prefix not found
+    }
+    
+    // Move past "/sensor/camera/"
+    start += prefix.length(); 
+    
+    size_t end = path.find('/', start);
+    return path.substr(start, end - start);
+}
+
+// Helper function to convert builtin_interfaces::msg::Time to nanoseconds
+int64_t toNanoseconds(const builtin_interfaces::msg::Time& timestamp) {
+    return static_cast<int64_t>(timestamp.sec) * 1'000'000'000 + timestamp.nanosec;
+}
+
+// Function to find the closest index in a sorted vector for a given timestamp
+size_t find_closest_timestamp(const std::vector<DataMeta>& target_vector, 
+                              const builtin_interfaces::msg::Time& timestamp, 
+                              size_t& last_index) {
+                                
+    int64_t timestamp_ns = toNanoseconds(timestamp);
+
+    // Start from the last known index
+    size_t closest_index = last_index;
+    int64_t min_diff = std::numeric_limits<int64_t>::max();
+
+    // Iterate forward through the sorted vector
+    for (size_t i = last_index; i < target_vector.size(); ++i) {
+        int64_t target_ns = toNanoseconds(target_vector[i].timestamp);
+        int64_t diff = std::abs(target_ns - timestamp_ns);
+
+        // Update closest index and minimum difference
+        if (diff < min_diff) {
+            min_diff = diff;
+            closest_index = i;
+        } else {
+            // Since the vector is sorted, stop when differences start increasing
+            break;
+        }
+    }
+
+    // Update the last index for the next call
+    last_index = closest_index;
+    return closest_index;
+}
+
+} // namespace rosbag2_exporter
+
+#endif // UTILS_HPP

--- a/include/rosbag2_exporter/utils.hpp
+++ b/include/rosbag2_exporter/utils.hpp
@@ -28,7 +28,7 @@ std::string get_cam_name(const std::string& path) {
 
 // Helper function to convert builtin_interfaces::msg::Time to nanoseconds
 int64_t toNanoseconds(const builtin_interfaces::msg::Time& timestamp) {
-    return static_cast<int64_t>(timestamp.sec) * 1'000'000'000 + timestamp.nanosec;
+    return static_cast<int64_t>(timestamp.sec) * std::pow(10, 9) + timestamp.nanosec;
 }
 
 // Function to find the closest index in a sorted vector for a given timestamp

--- a/src/bag_exporter.cpp
+++ b/src/bag_exporter.cpp
@@ -253,6 +253,13 @@ void BagExporter::create_metadata_file()
     sync_group["stamp"]["sec"] = main_data_meta.timestamp.sec;
     sync_group["stamp"]["nanosec"] = main_data_meta.timestamp.nanosec;
     sync_group["lidar"]["global_id"] = main_data_meta.global_id;
+
+    // Save file name relative to rosbag_base_name_
+    std::string abs_path_prefix = output_dir_ + "/" + rosbag_base_name_ + "/";
+    if (main_data_meta.data_path.find(abs_path_prefix) == 0)
+    {
+        main_data_meta.data_path.erase(0, abs_path_prefix.length());
+    }
     sync_group["lidar"]["file"] = main_data_meta.data_path;
 
     auto& curr_lidar_time = main_data_meta.timestamp;
@@ -283,6 +290,11 @@ void BagExporter::create_metadata_file()
         YAML::Node cam;
         cam["global_id"] = current_cam_meta.global_id;
         cam["name"] = get_cam_name(topics_[k].name);
+        
+        // Save file name relative to rosbag_base_name_
+        if (current_cam_meta.data_path.find(abs_path_prefix) == 0) { 
+          current_cam_meta.data_path.erase(0, abs_path_prefix.length());  
+        }
         cam["file"] = current_cam_meta.data_path;
 
         cameras.push_back(cam);

--- a/src/bag_exporter.cpp
+++ b/src/bag_exporter.cpp
@@ -268,7 +268,7 @@ void BagExporter::create_metadata_file()
 
     auto& curr_lidar_time = main_data_meta.timestamp;
 
-    // Where the cameras' YAML data willl be saved
+    // Where the cameras' YAML data will be saved
     YAML::Node cameras;
 
     // Find closest timestamp for each camera

--- a/src/bag_exporter.cpp
+++ b/src/bag_exporter.cpp
@@ -5,6 +5,10 @@
 
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include "rosbag2_exporter/bag_exporter.hpp"
+#include "rosbag2_exporter/utils.hpp"
+#include <chrono>
+#include <fstream>
+#include <yaml-cpp/yaml.h>
 
 namespace rosbag2_exporter
 {
@@ -35,6 +39,9 @@ BagExporter::BagExporter(const rclcpp::NodeOptions & options)
 
   // Start exporting
   export_bag();
+
+  // Create Metadata
+  create_metadata_file();
 }
 
 void BagExporter::load_configuration(const std::string & config_file)
@@ -90,11 +97,11 @@ void BagExporter::load_configuration(const std::string & config_file)
 void BagExporter::setup_handlers()
 {
   // Extract base name from rosbag file
-  std::string rosbag_base_name = std::filesystem::path(bag_path_).stem().string();
+  rosbag_base_name_ = std::filesystem::path(bag_path_).stem().string();
   
   for (const auto & topic : topics_) {
     // Create directory for each topic
-    std::string abs_topic_dir = output_dir_ + "/" + rosbag_base_name + "/" + topic.topic_dir;
+    std::string abs_topic_dir = output_dir_ + "/" + rosbag_base_name_ + "/" + topic.topic_dir;
 
     // Initialize handler based on message type
     if (topic.type == MessageType::PointCloud2) {
@@ -162,8 +169,10 @@ void BagExporter::export_bag()
     }
   }
 
+  auto start_time_point = std::chrono::high_resolution_clock::now();
+  // Global id counter
+  size_t global_id = 0;
   // Read and process messages
-  size_t total_messages = 0;
   while (reader.has_next()) {
     auto serialized_msg = reader.read_next();
     std::string topic = serialized_msg->topic_name;
@@ -193,19 +202,96 @@ void BagExporter::export_bag()
           ser_msg.get_rcl_serialized_message().buffer_length = buffer_length;
 
           // Process the message
-          handler_it->second.handler->process_message(ser_msg, topic, current_index);
+          handler_it->second.handler->process_message(ser_msg, topic, global_id);
         }
       } else {
         RCLCPP_WARN(this->get_logger(), "No configuration found for topic: %s", topic.c_str());
       }
 
       handler_it->second.current_index++;
-      total_messages++;
+      global_id++;
     }
   }
 
-  RCLCPP_INFO(this->get_logger(), "Export completed. Total messages processed: %zu", total_messages);
-  rclcpp::shutdown();
+  auto end_time_point = std::chrono::high_resolution_clock::now();
+  std::chrono::duration<double> duration = end_time_point - start_time_point;
+  double elapsed_time = duration.count();
+
+  RCLCPP_INFO(this->get_logger(), "Export completed. Total messages processed: %zu in %f secs",
+              global_id, elapsed_time);
+}
+
+void BagExporter::create_metadata_file()
+{
+
+  // YAML C++ preserves list order, so topics_[0] corresponds to  
+  // the first sensor defined in the YAML file, used as the time sync reference.
+  auto & main_sensor_handler = handlers_[topics_[0].name].handler;
+  RCLCPP_INFO(this->get_logger(), "Main sensor topic: %s", topics_[0].name.c_str());
+
+  std::vector<size_t> msg_index(topics_.size(), 0);
+
+  // Define YAML root
+  YAML::Node root;
+
+  size_t sync_group_id = 0;
+
+  // Co-relate other sensors timestamps based on main sensor
+  for (auto &main_data_meta : main_sensor_handler->data_meta_vec_)
+  {
+    YAML::Node sync_group;
+    sync_group["id"] = sync_group_id;
+    sync_group["stamp"]["sec"] = main_data_meta.timestamp.sec;
+    sync_group["stamp"]["nanosec"] = main_data_meta.timestamp.nanosec;
+    sync_group["lidar"]["global_id"] = main_data_meta.global_id;
+    sync_group["lidar"]["file"] = main_data_meta.data_path;
+
+    auto& curr_lidar_time = main_data_meta.timestamp;
+
+    // Where the cameras' YAML data willl be saved
+    YAML::Node cameras;
+
+    // Find closest timestamp for each camera
+    for (int k = 0; k < topics_.size(); k++)
+    {
+        // Only process camera messages
+        if (topics_[k].type != MessageType::Image &&
+            topics_[k].type != MessageType::CompressedImage &&
+            topics_[k].type != MessageType::DepthImage &&
+            topics_[k].type != MessageType::IRImage)
+        {
+            continue;
+        }
+
+        // Get current camera metadata
+        auto &curr_cam_handler = handlers_[topics_[k].name].handler;
+        auto &current_meta_data_vec = curr_cam_handler->data_meta_vec_;
+        size_t closest_time_index = find_closest_timestamp(current_meta_data_vec,
+                                                            curr_lidar_time, msg_index[k]);
+        
+        // Create YAML metadata based on the found time index
+        auto &current_cam_meta = current_meta_data_vec[closest_time_index];
+        YAML::Node cam;
+        cam["global_id"] = current_cam_meta.global_id;
+        cam["name"] = get_cam_name(topics_[k].name);
+        cam["file"] = current_cam_meta.data_path;
+
+        cameras.push_back(cam);
+    }
+
+    // Finish YAML data
+    sync_group["cameras"] = cameras;
+    root["time_sync_groups"].push_back(sync_group);
+
+    // Save the file in the rosbag output directory
+    std::string yaml_path = output_dir_ + "/" + rosbag_base_name_ + "/" + "time_sync_metadata.yaml";
+    std::ofstream yaml_file(yaml_path);
+    yaml_file << root;
+    yaml_file.close();
+
+    ++sync_group_id;
+
+  }
 }
 
 }  // namespace rosbag2_exporter

--- a/src/bag_exporter.cpp
+++ b/src/bag_exporter.cpp
@@ -243,6 +243,10 @@ void BagExporter::create_metadata_file()
   // Define YAML root
   YAML::Node root;
 
+  // Save which rosbag was used to extract the data
+  root["rosbags"] = YAML::Node(YAML::NodeType::Sequence);
+  root["rosbags"].push_back(std::filesystem::path(bag_path_).filename().string());
+
   size_t sync_group_id = 0;
 
   // Co-relate other sensors timestamps based on main sensor

--- a/src/bag_exporter.cpp
+++ b/src/bag_exporter.cpp
@@ -312,7 +312,7 @@ void BagExporter::create_metadata_file()
   }
 
   // Save the file in the rosbag output directory
-  std::string yaml_path = output_dir_ + "/" + rosbag_base_name_ + "/" + "time_sync_metadata.yaml";
+  std::string yaml_path = output_dir_ + "/" + rosbag_base_name_ + "/" + "export_metadata.yaml";
   std::ofstream yaml_file(yaml_path);
   yaml_file << root;
   yaml_file.close();


### PR DESCRIPTION
 - Add LiDAR-camera timestamp synchronisation support
    - Add `create_metadata_file()` function to:
      - Associate camera timestamps with a LiDAR point cloud
      - Use the timestamp of the first topic defined in the `config_file`
        `topics` list as the main time reference
      - Synchronise only `Image`, `CompressedImage`, `DepthImage`, and `IRImage`
        message types
      -  Save the `.mcap` file used to export the data
      - Generate a `export_metadata.yaml` file in the output data parent directory with
         the summary
    - Modify `export_bag()` function to:
      - Track a `global_id` counter to be passed to each sensor handler, ensuring
        each output file has a unique identifier
      - Measure rosbag reading and data extraction processing time and log it
    - Modify `BaseHandler` and child classes to:
      - Support a new `DataMeta` struct
      - Continuously generate `DataMeta` objects and push them to a new
        public `data_meta_vec_` vector
      - Use `index` as global identifier rather than a local one
    - Add `utils.hpp` to define functions for repetitive tasks
    - Add comment in `exporter_config.yaml` example config file to clarify the role
      of the first defined topic in the `topics` list for time synchronisation
 - Enhance logging and meta file creation
   - Downgrade the handler's "Successfully wrote x file" log
     to `DEBUG` to reduce terminal clutter
   - Extract the total number of messages to be
     processed and display a progress bar animation
   - Rephrase some `INFO` logs for improved clarity and coherence
   - Create the metadata file only after all timestamps have been sorted
 - Save filenames relative to the extraction directory `<output_dir>/rosbag_name`